### PR TITLE
Resolve copy/paste error when checking storages

### DIFF
--- a/duplicacy-util.go
+++ b/duplicacy-util.go
@@ -495,7 +495,7 @@ func performBackup() error {
 			if configFile.checkInfo[i]["all"] == "true" {
 				cmdArgs = append(cmdArgs, "-all")
 			}
-			logMessage(logger, fmt.Sprint("Checking storage ", configFile.pruneInfo[i]["storage"]))
+			logMessage(logger, fmt.Sprint("Checking storage ", configFile.checkInfo[i]["storage"]))
 			if debugFlag {
 				logMessage(logger, fmt.Sprint("Executing: ", duplicacyPath, cmdArgs))
 			}


### PR DESCRIPTION
Fixes first problem identified in #7 (panic: runtime error: index out of range)