### PR TITLE
Add support for backup config files with arrays

### DIFF
--- a/configBackup_test.go
+++ b/configBackup_test.go
@@ -13,3 +13,43 @@ func TestValidConfigWithNumberedKeys(t *testing.T) {
 		t.Error(err)
 	}
 }
+
+func TestValidConfigWithArray(t *testing.T) {
+	configFile = newConfigurationFile()
+	configFile.setConfig("array")
+	globalStorageDirectory = "test/assets/backupConfigs/"
+	err := configFile.loadConfig(true, true)
+	if err != nil {
+		t.Error(err)
+	}
+}
+
+func TestValidConfig_NoCopySection(t *testing.T) {
+	configFile = newConfigurationFile()
+	configFile.setConfig("noCopySection")
+	globalStorageDirectory = "test/assets/backupConfigs/"
+	err := configFile.loadConfig(true, true)
+	if err != nil {
+		t.Error(err)
+	}
+}
+
+func TestInvalidConfig_MissingStorage(t *testing.T) {
+	configFile = newConfigurationFile()
+	configFile.setConfig("missingStorage")
+	globalStorageDirectory = "test/assets/backupConfigs/"
+	err := configFile.loadConfig(true, true)
+	if err == nil {
+		t.Error("Invalid storage configuration error should have been returned")
+	}
+}
+
+func TestInvalidConfig_MissingStorageName(t *testing.T) {
+	configFile = newConfigurationFile()
+	configFile.setConfig("missingStorageName")
+	globalStorageDirectory = "test/assets/backupConfigs/"
+	err := configFile.loadConfig(true, true)
+	if err == nil {
+		t.Error("Invalid storage configuration error should have been returned")
+	}
+}

--- a/configBackup_test.go
+++ b/configBackup_test.go
@@ -1,0 +1,15 @@
+package main
+
+import (
+	"testing"
+)
+
+func TestValidConfigWithNumberedKeys(t *testing.T) {
+	configFile = newConfigurationFile()
+	configFile.setConfig("numberedKeys")
+	globalStorageDirectory = "test/assets/backupConfigs/"
+	err := configFile.loadConfig(true, true)
+	if err != nil {
+		t.Error(err)
+	}
+}

--- a/test/assets/backupConfigs/array.yml
+++ b/test/assets/backupConfigs/array.yml
@@ -1,0 +1,26 @@
+repository: .
+
+storage:
+    - name: b2
+      threads: 10
+    - name: azure-direct
+      threads: 5
+    - name: default-threads
+
+copy:
+    - from: b2
+      to: azure
+      threads: 10
+    - from: b2
+      to: default-threads
+
+prune:
+    - storage: b2
+      keep: "0:365 30:180 7:30 1:7"
+    - storage: azure
+      keep: "0:365 30:180 7:30 1:7"
+
+check:
+    - storage: b2
+      all: true
+    - storage: azure

--- a/test/assets/backupConfigs/missingStorage.yml
+++ b/test/assets/backupConfigs/missingStorage.yml
@@ -1,0 +1,19 @@
+repository: .
+
+copy:
+    - from: b2
+      to: azure
+      threads: 10
+    - from: b2
+      to: default-threads
+
+prune:
+    - storage: b2
+      keep: "0:365 30:180 7:30 1:7"
+    - storage: azure
+      keep: "0:365 30:180 7:30 1:7"
+
+check:
+    - storage: b2
+      all: true
+    - storage: azure

--- a/test/assets/backupConfigs/missingStorageName.yml
+++ b/test/assets/backupConfigs/missingStorageName.yml
@@ -1,0 +1,26 @@
+repository: .
+
+storage:
+    - name: b2
+      threads: 10
+    - name: azure-direct
+      threads: 5
+    - threads: 1
+
+copy:
+    - from: b2
+      to: azure
+      threads: 10
+    - from: b2
+      to: default-threads
+
+prune:
+    - storage: b2
+      keep: "0:365 30:180 7:30 1:7"
+    - storage: azure
+      keep: "0:365 30:180 7:30 1:7"
+
+check:
+    - storage: b2
+      all: true
+    - storage: azure

--- a/test/assets/backupConfigs/noCopySection.yml
+++ b/test/assets/backupConfigs/noCopySection.yml
@@ -1,0 +1,19 @@
+repository: .
+
+storage:
+    - name: b2
+      threads: 10
+    - name: azure-direct
+      threads: 5
+    - name: default-threads
+
+prune:
+    - storage: b2
+      keep: "0:365 30:180 7:30 1:7"
+    - storage: azure
+      keep: "0:365 30:180 7:30 1:7"
+
+check:
+    - storage: b2
+      all: true
+    - storage: azure

--- a/test/assets/backupConfigs/numberedKeys.yml
+++ b/test/assets/backupConfigs/numberedKeys.yml
@@ -1,0 +1,31 @@
+repository: .
+
+storage:
+    1:
+        name: b2
+        threads: 10
+    2:
+        name: azure-direct
+        threads: 5
+
+copy:
+    1:
+        from: b2
+        to: azure
+        threads: 10
+
+prune:
+    1:
+        storage: b2
+        keep: "0:365 30:180 7:30 1:7"
+    2:
+        storage: azure
+        keep: "0:365 30:180 7:30 1:7"
+
+check:
+    1:
+        storage: b2
+        all: true
+    2:
+        storage: azure
+        all: true

--- a/test/assets/backupConfigs/numberedKeys.yml
+++ b/test/assets/backupConfigs/numberedKeys.yml
@@ -7,12 +7,17 @@ storage:
     2:
         name: azure-direct
         threads: 5
+    3:
+        name: default-threads
 
 copy:
     1:
         from: b2
         to: azure
         threads: 10
+    2:
+        from: b2
+        to: default-threads
 
 prune:
     1:
@@ -28,4 +33,3 @@ check:
         all: true
     2:
         storage: azure
-        all: true


### PR DESCRIPTION
* Added tests for existing format with items in a map keyed by number
* Added tests for new format and a few tests for some invalid configurations

Fixes #19 

Note that I have not thoroughly tested this yet outside of the tests cases included; will be switching my backups to a build based on this to see how it is working.

The actual code saves some lines, most of the additions are from the new tests.

It now reads all the configuration values, then does a validation and setting of defaults. Previously it was intermixed.

When it reads the values it reads them directly into a `[]map[string]string`. Alternatively they could have been read using viper's `UnmarshalKey`but this would require a struct for each section. And since the rest of the program uses `map[string]string` as the end result it seemed overkill. However it would be something like:

```golang
var storage []struct{
  Name string
  Threads int
  VssFlag bool
  VssTimeout int
}
viper.UnmarshalKey("storage", &storage)
```

This was a bit more work than I was expecting but I got to learn a lot which is the whole point!