### PR TITLE
Change contentType for SetBody from "text" to "text/plain" to resolve Amazon SES sending issue

### DIFF
--- a/sendmail.go
+++ b/sendmail.go
@@ -213,7 +213,7 @@ func sendMailMessage(subject string, bodyHTML []string, bodyText []string) error
 	m.SetHeader("From", emailFromAddress)
 	m.SetHeader("To", emailToAddress)
 	m.SetHeader("Subject", subject)
-	m.SetBody("text", strings.Join(bodyText, "\r\n"))
+	m.SetBody("text/plain", strings.Join(bodyText, "\r\n"))
 	if len(bodyHTML) != 0 {
 		m.AddAlternative("text/html", strings.Join(bodyHTML, "\r\n"))
 	}


### PR DESCRIPTION
https://github.com/jeffaco/duplicacy-util/issues/36

Tested on my personal Amazon SES account. Issue was reproduced without this change, and emails send fine with the change.