### PR TITLE
Parse operation configs only if they are specified

### DIFF
--- a/configBackup.go
+++ b/configBackup.go
@@ -78,71 +78,73 @@ func (config *configurationFile) loadConfig(verboseFlag bool, debugFlag bool) er
 	}
 
 	// Populate information from configuration
-	config.backupInfo = readSection(v, config.configFilename, "storage")
-	config.copyInfo = readSection(v, config.configFilename, "copy")
-	config.pruneInfo = readSection(v, config.configFilename, "prune")
-	config.checkInfo = readSection(v, config.configFilename, "check")
-
-	// Validate, set defaults
-	if len(config.backupInfo) == 0 {
-		err = errors.New("no storage locations defined in configuration")
-		logError(nil, fmt.Sprint("Error: ", err))
-	} else {
-		for i, bi := range config.backupInfo {
-			if bi["name"] == "" {
-				err = fmt.Errorf("missing mandatory storage field: %d.name", i)
-				logError(nil, fmt.Sprint("Error: ", err))
-			}
-		}
-	}
-
-	for i, ci := range config.copyInfo {
-		if ci["from"] == "" {
-			err = fmt.Errorf("missing mandatory from field: %d.from", i)
-			logError(nil, fmt.Sprint("Error: ", err))
-		}
-		if ci["to"] == "" {
-			err = fmt.Errorf("missing mandatory to field: %d.to", i)
-			logError(nil, fmt.Sprint("Error: ", err))
-		}
-	}
-
-	if len(config.pruneInfo) == 0 {
-		err = errors.New("no prune locations defined in configuration")
-		logError(nil, fmt.Sprint("Error: ", err))
-	}
-
-	for i, pi := range config.pruneInfo {
-		if pi["storage"] == "" {
-			err = fmt.Errorf("missing mandatory prune field: %d.storage", i)
-			logError(nil, fmt.Sprint("Error: ", err))
-		}
-		if pi["keep"] == "" {
-			err = fmt.Errorf("missing mandatory prune field: %d.keep", i)
+	if cmdBackup {
+		config.backupInfo = readSection(v, config.configFilename, "storage")
+		if len(config.backupInfo) == 0 {
+			err = errors.New("no storage locations defined in configuration")
 			logError(nil, fmt.Sprint("Error: ", err))
 		} else {
-			// Split/join to get "-keep " before each element
-			splitList := strings.Split(pi["keep"], " ")
-			for i, element := range splitList {
-				splitList[i] = "-keep " + element
+			for i, bi := range config.backupInfo {
+				if bi["name"] == "" {
+					err = fmt.Errorf("missing mandatory storage field: %d.name", i)
+					logError(nil, fmt.Sprint("Error: ", err))
+				}
 			}
-
-			pi["keep"] = strings.Join(splitList, " ")
 		}
 	}
-
-	if len(config.checkInfo) == 0 {
-		err = errors.New("no check locations defined in configuration")
-		logError(nil, fmt.Sprint("Error: ", err))
-	} else {
-		for i, ci := range config.checkInfo {
-			if ci["storage"] == "" {
-				err = fmt.Errorf("missing mandatory check field: %d.storage", i)
+	if cmdCopy {
+		config.copyInfo = readSection(v, config.configFilename, "copy")
+		for i, ci := range config.copyInfo {
+			if ci["from"] == "" {
+				err = fmt.Errorf("missing mandatory from field: %d.from", i)
+				logError(nil, fmt.Sprint("Error: ", err))
+			}
+			if ci["to"] == "" {
+				err = fmt.Errorf("missing mandatory to field: %d.to", i)
 				logError(nil, fmt.Sprint("Error: ", err))
 			}
 		}
 	}
+	if cmdPrune {
+		config.pruneInfo = readSection(v, config.configFilename, "prune")
+		if len(config.pruneInfo) == 0 {
+			err = errors.New("no prune locations defined in configuration")
+			logError(nil, fmt.Sprint("Error: ", err))
+		}
 
+		for i, pi := range config.pruneInfo {
+			if pi["storage"] == "" {
+				err = fmt.Errorf("missing mandatory prune field: %d.storage", i)
+				logError(nil, fmt.Sprint("Error: ", err))
+			}
+			if pi["keep"] == "" {
+				err = fmt.Errorf("missing mandatory prune field: %d.keep", i)
+				logError(nil, fmt.Sprint("Error: ", err))
+			} else {
+				// Split/join to get "-keep " before each element
+				splitList := strings.Split(pi["keep"], " ")
+				for i, element := range splitList {
+					splitList[i] = "-keep " + element
+				}
+
+				pi["keep"] = strings.Join(splitList, " ")
+			}
+		}
+	}
+	if cmdCheck {
+		config.checkInfo = readSection(v, config.configFilename, "check")
+		if len(config.checkInfo) == 0 {
+			err = errors.New("no check locations defined in configuration")
+			logError(nil, fmt.Sprint("Error: ", err))
+		} else {
+			for i, ci := range config.checkInfo {
+				if ci["storage"] == "" {
+					err = fmt.Errorf("missing mandatory check field: %d.storage", i)
+					logError(nil, fmt.Sprint("Error: ", err))
+				}
+			}
+		}
+	}
 	// Generate verbose/debug output if requested (assuming no fatal errors)
 
 	if err == nil {

--- a/configBackup_test.go
+++ b/configBackup_test.go
@@ -10,6 +10,10 @@ func TestValidConfigWithNumberedKeys(t *testing.T) {
 	defer func() {
 		quietFlag = false
 	}()
+	cmdBackup = true
+	cmdCopy = true
+	cmdPrune = true
+	cmdCheck = true
 
 	// Read the expected configuration file under test
 	configFile = newConfigurationFile()


### PR DESCRIPTION
This fixes a bug where duplicacy-util tries to parse configurations for all operations, even when they aren't specified. Now each configuration is only parsed when the corresponding `cmd*` flag is passed. It does not change any behavior for the end user.

`performBackup()` in `backup-ops.go` correctly honors these flags already, so not parsing the configs should not break anything.